### PR TITLE
Update xero_client for current_user's access_token

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,6 +30,10 @@ module ApplicationHelper
     }
     @xero_client ||= XeroRuby::ApiClient.new(credentials: creds)
 
+    if current_user&.token_set
+      @xero_client.set_token_set(current_user.token_set)
+    end
+
     return @xero_client
   end
 


### PR DESCRIPTION
My user was getting 401 errors until I started updating `XeroRuby::ApiClient` with the current_user's access token.